### PR TITLE
TW-339 andorid sdk 26에서 refresh button으로 갱신안되는 이슈

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-todayweather-android-widget",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "todayweather android widget",
   "cordova": {
     "id": "cordova-plugin-todayweather-android-widget",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-todayair-android-widget" version="0.2.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-todayair-android-widget" version="0.2.7" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>todayairAndroidWidget</name>
     <js-module name="todayweatherAndroidWidget" src="www/todayweatherAndroidWidget.js">
         <clobbers target="cordova.plugins.todayweatherAndroidWidget" />

--- a/src/android/widget/Provider/TwWidgetProvider.java
+++ b/src/android/widget/Provider/TwWidgetProvider.java
@@ -105,8 +105,16 @@ public class TwWidgetProvider extends AppWidgetProvider {
     static public void setPendingIntentToRefresh(Context context, int appWidgetId, RemoteViews views) {
         Intent serviceIntent = new Intent(context, WidgetUpdateService.class);
         serviceIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
-        PendingIntent pendingIntent = PendingIntent.getService(context, appWidgetId, serviceIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            pendingIntent = PendingIntent.getForegroundService(context, appWidgetId,
+                    serviceIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        }
+        else {
+            pendingIntent = PendingIntent.getService(context, appWidgetId, serviceIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT);
+        }
+
         views.setOnClickPendingIntent(R.id.ic_refresh, pendingIntent);
         views.setOnClickPendingIntent(R.id.pubdate, pendingIntent);
     }


### PR DESCRIPTION
- 26이상에서는 PendingIntent.getForegroundService() 사용